### PR TITLE
Removed an extra paragraph in the ContainerInterface standard

### DIFF
--- a/docs/ContainerInterface.md
+++ b/docs/ContainerInterface.md
@@ -6,9 +6,6 @@ This document describes a common interface for dependency injection containers.
 The goal set by `ContainerInterface` is to standardize how frameworks and libraries make use of a
 container to obtain objects and parameters (called *entries* in the rest of this document).
 
-Frameworks and CMSs that have custom needs MAY extend 
-the interface for their own purpose, but SHOULD remain compatible with this document. 
-
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in [RFC 2119][].


### PR DESCRIPTION
Minor change.

In the introduction, I removed:

> Frameworks and CMSs that have custom needs MAY extend the interface for their own purpose, but SHOULD remain compatible with this document.

I think this is unnecessary as implementors implement this standard or not, it's up to them (hence we don't say they should be compatible). And we don't care if they extend this interface as long as they implement it, and "allowing" them to do so feels weird.
