### PR TITLE
Adding a middlewares section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ View open [request for comments](https://github.com/container-interop/container-
 
 ### Projects using `ContainerInterface`
 
-- [Woohoo Labs. API Framework](https://github.com/woohoolabs/api-framework): a
-  micro-framework for writing APIs
 - [interop.silex.di](https://github.com/thecodingmachine/interop.silex.di): an
   extension to [Silex](http://silex.sensiolabs.org/) that adds support for any
   *container-interop* compatible container
+- [Woohoo Labs. API Framework](https://github.com/woohoolabs/api-framework): a
+  micro-framework for writing APIs
 
 ## Workflow
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 *container-interop* tries to identify and standardize features in *container* objects (service locators,
 dependency injection containers, etc.) to achieve interopererability.
 
-Through discussions and trials, we try to create a standard, made of common interfaces but also recommendations. 
+Through discussions and trials, we try to create a standard, made of common interfaces but also recommendations.
 
 If PHP projects that provide container implementations begin to adopt these common standards, then PHP
 applications and projects that use containers can depend on the common interfaces instead of specific
@@ -42,7 +42,7 @@ between minor versions.
 Describes the interface of a container that exposes methods to read its entries.
 - [*Delegate lookup feature*](docs/Delegate-lookup.md).
 [Meta Document](docs/Delegate-lookup-meta.md).
-Describes the ability for a container to delegate the lookup of its dependencies to a third-party container. This 
+Describes the ability for a container to delegate the lookup of its dependencies to a third-party container. This
 feature lets several containers work together in a single application.
 
 ### Proposed
@@ -66,6 +66,13 @@ View open [request for comments](https://github.com/container-interop/container-
 - [Mouf](http://mouf-php.com)
 - [PHP-DI](http://php-di.org)
 - [PimpleInterop](https://github.com/moufmouf/pimple-interop)
+
+### Middlewares implementing `ContainerInterface`
+
+- [Alias-Container](https://github.com/thecodingmachine/alias-container): add
+  aliases support to any container
+- [Prefixer-Container](https://github.com/thecodingmachine/prefixer-container):
+  dynamically prefix identifiers
 
 ## Workflow
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ View open [request for comments](https://github.com/container-interop/container-
 
 ### Projects implementing `ContainerInterface`
 
-- [Acclimate](https://github.com/jeremeamia/acclimate-container)
+- [Acclimate](https://github.com/jeremeamia/acclimate-container): Adapters for
+  Aura.Di, Laravel, Nette DI, Pimple, Symfony DI, ZF2 Service manager, ZF2
+  Dependency injection and any container using `ArrayAccess`
 - [dcp-di](https://github.com/estelsmith/dcp-di)
 - [Mouf](http://mouf-php.com)
 - [Njasm Container](https://github.com/njasm/container)
@@ -73,6 +75,14 @@ View open [request for comments](https://github.com/container-interop/container-
   aliases support to any container
 - [Prefixer-Container](https://github.com/thecodingmachine/prefixer-container):
   dynamically prefix identifiers
+
+### Projects using `ContainerInterface`
+
+- [Woohoo Labs. API Framework](https://github.com/woohoolabs/api-framework): a
+  micro-framework for writing APIs
+- [interop.silex.di](https://github.com/thecodingmachine/interop.silex.di): an
+  extension to [Silex](http://silex.sensiolabs.org/) that adds support for any
+  *container-interop* compatible container
 
 ## Workflow
 


### PR DESCRIPTION
Hi!

I just added 2 references to projects I have been working on in the README.
These are not really containers, they are rather tools to be used with containers. Therefore, I created a new section "Middlewares" (I'm not sure the naming is correct...)

Those 2 projects are:

- [Alias-Container](https://github.com/thecodingmachine/alias-container): a simple utility class that creates aliases (to be used with a composite container). Very useful to add aliases support on containers that do not support aliasing.
- [Prefixer-Container](https://github.com/thecodingmachine/prefixer-container): another utility class that dynamically prefixes identifiers. Useful to "jail" a container in a given namespace (in order to avoid naming conflicts when several containers are used side-by-side).

Do you think these 2 references belong to the main README?