### PR TITLE
Added Prophiler to the list of projects using container-interop.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ View open [request for comments](https://github.com/container-interop/container-
 - [Woohoo Labs. Harmony](https://github.com/woohoolabs/harmony): a flexible
   micro-framework
 - [zend-expressive](https://github.com/zendframework/zend-expressive)
+- [Prophiler](https://github.com/fabfuel/prophiler)
 
 ## Workflow
 

--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ View open [request for comments](https://github.com/container-interop/container-
 - [interop.silex.di](https://github.com/thecodingmachine/interop.silex.di): an
   extension to [Silex](http://silex.sensiolabs.org/) that adds support for any
   *container-interop* compatible container
+- [Prophiler](https://github.com/fabfuel/prophiler)
 - [Slim v3](https://github.com/slimphp/Slim)
 - [Woohoo Labs. Harmony](https://github.com/woohoolabs/harmony): a flexible
   micro-framework
 - [zend-expressive](https://github.com/zendframework/zend-expressive)
-- [Prophiler](https://github.com/fabfuel/prophiler)
 
 ## Workflow
 


### PR DESCRIPTION
Prophiler is able to monitor the calls to the get() and has() methods of any container implementing container-interop.