### PR TITLE
add link to mindplay/walkway

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ View open [request for comments](https://github.com/container-interop/container-
   micro-framework
 - [zend-expressive](https://github.com/zendframework/zend-expressive)
 - [blast-facades](https://github.com/phpthinktank/blast-facades): Minimize complexity and represent dependencies as facades.
+- [mindplay/walkway](https://github.com/mindplay-dk/walkway): a modular request router.
 
 
 ## Workflow


### PR DESCRIPTION
With [release 3.0](https://github.com/mindplay-dk/walkway/releases/tag/3.0.0) today, this router now provides closure injection (via type-hints) through any container-interop implementation.