### PR TITLE
Add homepage.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "container-interop/container-interop",
     "type": "library",
     "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
+    "homepage": "https://github.com/container-interop/container-interop",
     "license": "MIT",
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Having a homepage link makes mirror and directory services such as those generated by Satis more convenient and nicer to use.