### PR TITLE
New has() behaviour

### DIFF
--- a/docs/ContainerInterface.md
+++ b/docs/ContainerInterface.md
@@ -33,8 +33,7 @@ Users of dependency injections containers (DIC) are referred to as `user`.
   MAY accept additional optional parameters.
 
 - `has` takes one unique parameter: an entry identifier. It MUST return `true`
-  if an entry identifier is known to the container, or `get` is capable of retrieving the entry,
-  and `false` if it is not.
+  if `get` is capable of retrieving the entry, and `false` if it is not.
   `has($id)` returning true does not mean that `get($id)` will not throw an exception.
   It does however mean that `get($id)` will not throw a `NotFoundException`.
 

--- a/docs/ContainerInterface.md
+++ b/docs/ContainerInterface.md
@@ -33,7 +33,8 @@ Users of dependency injections containers (DIC) are referred to as `user`.
   MAY accept additional optional parameters.
 
 - `has` takes one unique parameter: an entry identifier. It MUST return `true`
-  if an entry identifier is known to the container and `false` if it is not.
+  if an entry identifier is known to the container, or `get` is capable of retrieving the entry,
+  and `false` if it is not.
   `has($id)` returning true does not mean that `get($id)` will not throw an exception.
   It does however mean that `get($id)` will not throw a `NotFoundException`.
 


### PR DESCRIPTION
A proposal for 2.0, as discussed with @Ocramius.

Some discussion can be found [here](https://github.com/container-interop/container-interop/issues/37#issuecomment-182864049), although most of it was done via IRC.

To summarize, if the container supports auto-wiring, the behaviour of `has` is currently undefined – it may or may not return `true` depending on the implementation. Because of this, there is no way to determine whether or not it is capable of retrieving an entry.

This change means that implementations _must_ return true if they are capable of retrieving the entry, so they will most-likely need to use `get` internally – if it throws an exception (or is unable to retrieve the entry), it will return false. If auto-wiring is disabled, use of `get` would not be required.
