### PR TITLE
Burlap now supports delegate container

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ View open [request for comments](https://github.com/container-interop/container-
 
 ### Projects implementing the *delegate lookup* feature
 
+- [Burlap](https://github.com/codeeverything/burlap)
 - [InDI](https://github.com/idealogica/indi)
 - [League/Container](http://container.thephpleague.com/)
 - [Mouf](http://mouf-php.com)


### PR DESCRIPTION
I believe Burlap now supports the delegate container lookup as defined. Perhaps you could take a look and if you're happy merge in the changes to add it to the list? :)

https://github.com/codeeverything/burlap