### PR TITLE
Add download stats to "Projects using ContainerInterface"

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ View open [request for comments](https://github.com/container-interop/container-
 | [mindplay/walkway](https://github.com/mindplay-dk/walkway): a modular request router | ![](https://img.shields.io/packagist/dt/mindplay/walkway.svg) |
 | [mindplay/middleman](https://github.com/mindplay-dk/middleman): minimalist PSR-7 middleware dispatcher | ![](https://img.shields.io/packagist/dt/mindplay/middleman.svg) |
 | [PHP-DI/Invoker](https://github.com/PHP-DI/Invoker): extensible and configurable invoker/dispatcher | ![](https://img.shields.io/packagist/dt/php-di/invoker.svg) |
-| [prooph components](http://getprooph.org/): CQRS + ES Infrastructure | ![](https://img.shields.io/packagist/dt/prooph/processing.svg) |
 | [Prophiler](https://github.com/fabfuel/prophiler) | ![](https://img.shields.io/packagist/dt/fabfuel/prophiler.svg) |
 | [Silly](https://github.com/mnapoli/silly): CLI micro-framework | ![](https://img.shields.io/packagist/dt/mnapoli/silly.svg) |
 | [Slim v3](https://github.com/slimphp/Slim) | ![](https://img.shields.io/packagist/dt/slim/slim.svg) |

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ View open [request for comments](https://github.com/container-interop/container-
 
 ### Projects using `ContainerInterface`
 
+The list below contains only a sample of all the projects consuming `ContainerInterface`. For a more complete list have a look [here](http://packanalyst.com/class?q=Interop%5CContainer%5CContainerInterface).
+
 | | Downloads |
 | --- | --- |
 | [Adroit](https://github.com/bitexpert/adroit) | ![](https://img.shields.io/packagist/dt/bitexpert/adroit.svg) |

--- a/README.md
+++ b/README.md
@@ -94,21 +94,21 @@ View open [request for comments](https://github.com/container-interop/container-
 
 ### Projects using `ContainerInterface`
 
-- [Adroit](https://github.com/bitexpert/adroit)
-- [blast-facades](https://github.com/phpthinktank/blast-facades): Minimize complexity and represent dependencies as facades.
-- [interop.silex.di](https://github.com/thecodingmachine/interop.silex.di): an
+- ![](https://img.shields.io/packagist/dt/bitexpert/adroit.svg) [Adroit](https://github.com/bitexpert/adroit)
+- ![](https://img.shields.io/packagist/dt/blast/facades.svg) [blast-facades](https://github.com/phpthinktank/blast-facades): Minimize complexity and represent dependencies as facades.
+- ![](https://img.shields.io/packagist/dt/mouf/interop.silex.di.svg) [interop.silex.di](https://github.com/thecodingmachine/interop.silex.di): an
   extension to [Silex](http://silex.sensiolabs.org/) that adds support for any
   *container-interop* compatible container
-- [mindplay/walkway](https://github.com/mindplay-dk/walkway): a modular request router.
-- [mindplay/middleman](https://github.com/mindplay-dk/middleman): minimalist PSR-7 middleware dispatcher.
-- [PHP-DI/Invoker](https://github.com/PHP-DI/Invoker): extensible and configurable invoker/dispatcher
-- [prooph components](http://getprooph.org/): CQRS + ES Infrastructure
-- [Prophiler](https://github.com/fabfuel/prophiler)
-- [Silly](https://github.com/mnapoli/silly): CLI micro-framework
-- [Slim v3](https://github.com/slimphp/Slim)
-- [Woohoo Labs. Harmony](https://github.com/woohoolabs/harmony): a flexible
+- ![](https://img.shields.io/packagist/dt/mindplay/walkway.svg) [mindplay/walkway](https://github.com/mindplay-dk/walkway): a modular request router.
+- ![](https://img.shields.io/packagist/dt/mindplay/middleman.svg) [mindplay/middleman](https://github.com/mindplay-dk/middleman): minimalist PSR-7 middleware dispatcher.
+- ![](https://img.shields.io/packagist/dt/php-di/invoker.svg) [PHP-DI/Invoker](https://github.com/PHP-DI/Invoker): extensible and configurable invoker/dispatcher
+- ![](https://img.shields.io/packagist/dt/prooph/processing.svg) [prooph components](http://getprooph.org/): CQRS + ES Infrastructure
+- ![](https://img.shields.io/packagist/dt/fabfuel/prophiler.svg) [Prophiler](https://github.com/fabfuel/prophiler)
+- ![](https://img.shields.io/packagist/dt/mnapoli/silly.svg) [Silly](https://github.com/mnapoli/silly): CLI micro-framework
+- ![](https://img.shields.io/packagist/dt/slim/slim.svg) [Slim v3](https://github.com/slimphp/Slim)
+- ![](https://img.shields.io/packagist/dt/woohoolabs/harmony.svg) [Woohoo Labs. Harmony](https://github.com/woohoolabs/harmony): a flexible
   micro-framework
-- [zend-expressive](https://github.com/zendframework/zend-expressive)
+- ![](https://img.shields.io/packagist/dt/zendframework/zend-expressive.svg) [zend-expressive](https://github.com/zendframework/zend-expressive)
 
 
 ## Workflow

--- a/README.md
+++ b/README.md
@@ -94,21 +94,20 @@ View open [request for comments](https://github.com/container-interop/container-
 
 ### Projects using `ContainerInterface`
 
-- ![](https://img.shields.io/packagist/dt/bitexpert/adroit.svg) [Adroit](https://github.com/bitexpert/adroit)
-- ![](https://img.shields.io/packagist/dt/blast/facades.svg) [blast-facades](https://github.com/phpthinktank/blast-facades): Minimize complexity and represent dependencies as facades.
-- ![](https://img.shields.io/packagist/dt/mouf/interop.silex.di.svg) [interop.silex.di](https://github.com/thecodingmachine/interop.silex.di): an
-  extension to [Silex](http://silex.sensiolabs.org/) that adds support for any
-  *container-interop* compatible container
-- ![](https://img.shields.io/packagist/dt/mindplay/walkway.svg) [mindplay/walkway](https://github.com/mindplay-dk/walkway): a modular request router.
-- ![](https://img.shields.io/packagist/dt/mindplay/middleman.svg) [mindplay/middleman](https://github.com/mindplay-dk/middleman): minimalist PSR-7 middleware dispatcher.
-- ![](https://img.shields.io/packagist/dt/php-di/invoker.svg) [PHP-DI/Invoker](https://github.com/PHP-DI/Invoker): extensible and configurable invoker/dispatcher
-- ![](https://img.shields.io/packagist/dt/prooph/processing.svg) [prooph components](http://getprooph.org/): CQRS + ES Infrastructure
-- ![](https://img.shields.io/packagist/dt/fabfuel/prophiler.svg) [Prophiler](https://github.com/fabfuel/prophiler)
-- ![](https://img.shields.io/packagist/dt/mnapoli/silly.svg) [Silly](https://github.com/mnapoli/silly): CLI micro-framework
-- ![](https://img.shields.io/packagist/dt/slim/slim.svg) [Slim v3](https://github.com/slimphp/Slim)
-- ![](https://img.shields.io/packagist/dt/woohoolabs/harmony.svg) [Woohoo Labs. Harmony](https://github.com/woohoolabs/harmony): a flexible
-  micro-framework
-- ![](https://img.shields.io/packagist/dt/zendframework/zend-expressive.svg) [zend-expressive](https://github.com/zendframework/zend-expressive)
+| | Downloads |
+| --- | --- |
+| [Adroit](https://github.com/bitexpert/adroit) | ![](https://img.shields.io/packagist/dt/bitexpert/adroit.svg) |
+| [blast-facades](https://github.com/phpthinktank/blast-facades): Minimize complexity and represent dependencies as facades. | ![](https://img.shields.io/packagist/dt/blast/facades.svg) |
+| [interop.silex.di](https://github.com/thecodingmachine/interop.silex.di): an extension to [Silex](http://silex.sensiolabs.org/) that adds support for any *container-interop* compatible container | ![](https://img.shields.io/packagist/dt/mouf/interop.silex.di.svg) |
+| [mindplay/walkway](https://github.com/mindplay-dk/walkway): a modular request router | ![](https://img.shields.io/packagist/dt/mindplay/walkway.svg) |
+| [mindplay/middleman](https://github.com/mindplay-dk/middleman): minimalist PSR-7 middleware dispatcher | ![](https://img.shields.io/packagist/dt/mindplay/middleman.svg) |
+| [PHP-DI/Invoker](https://github.com/PHP-DI/Invoker): extensible and configurable invoker/dispatcher | ![](https://img.shields.io/packagist/dt/php-di/invoker.svg) |
+| [prooph components](http://getprooph.org/): CQRS + ES Infrastructure | ![](https://img.shields.io/packagist/dt/prooph/processing.svg) |
+| [Prophiler](https://github.com/fabfuel/prophiler) | ![](https://img.shields.io/packagist/dt/fabfuel/prophiler.svg) |
+| [Silly](https://github.com/mnapoli/silly): CLI micro-framework | ![](https://img.shields.io/packagist/dt/mnapoli/silly.svg) |
+| [Slim v3](https://github.com/slimphp/Slim) | ![](https://img.shields.io/packagist/dt/slim/slim.svg) |
+| [Woohoo Labs. Harmony](https://github.com/woohoolabs/harmony): a flexible micro-framework | ![](https://img.shields.io/packagist/dt/woohoolabs/harmony.svg) |
+| [zend-expressive](https://github.com/zendframework/zend-expressive) | ![](https://img.shields.io/packagist/dt/zendframework/zend-expressive.svg) |
 
 
 ## Workflow


### PR DESCRIPTION
Projects consuming `ContainerInterface` are very important: they show the standard is used.

I have added download badges to each of them so that everyone can get a better picture of how much `container-interop` is actually used, *not necessarily by implementors but also by consumers*.

In a second commit I have turned the list into a table, it's a little bit nicer IMO. Here is the final layout:

![capture d ecran 2016-07-14 a 17 42 25](https://cloud.githubusercontent.com/assets/720328/16845854/a4a0bf2a-49ea-11e6-9af3-b882a90c5487.png)

I could do that for other package lists (and maybe we could group `Projects implementing ContainerInterface` and `Projects implementing the delegate lookup feature` into one table), but it takes quite some time so I focused on the most important list first.