### PR TITLE
Adding Splash to the projects using container-interop

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The list below contains only a sample of all the projects consuming `ContainerIn
 | [Prophiler](https://github.com/fabfuel/prophiler) | ![](https://img.shields.io/packagist/dt/fabfuel/prophiler.svg) |
 | [Silly](https://github.com/mnapoli/silly): CLI micro-framework | ![](https://img.shields.io/packagist/dt/mnapoli/silly.svg) |
 | [Slim v3](https://github.com/slimphp/Slim) | ![](https://img.shields.io/packagist/dt/slim/slim.svg) |
+| [Splash](http://mouf-php.com/packages/mouf/mvc.splash-common/version/8.0-dev/README.md) | ![](https://img.shields.io/packagist/dt/mouf/mvc.splash-common.svg) |
 | [Woohoo Labs. Harmony](https://github.com/woohoolabs/harmony): a flexible micro-framework | ![](https://img.shields.io/packagist/dt/woohoolabs/harmony.svg) |
 | [zend-expressive](https://github.com/zendframework/zend-expressive) | ![](https://img.shields.io/packagist/dt/zendframework/zend-expressive.svg) |
 


### PR DESCRIPTION
Just realized I also forgot to add a project to the list of projects using ContainerInterop.

Here is Splash: an annotation based router that should be a grand winner in the interoperability bingo :) :
- Uses PSR 1/2/3/4/6/7
- Uses container-interop
- Uses container-interop/service-provider
