### PR TITLE
Migrating container-interop to PSR-11

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,19 @@
 [![Latest Stable Version](https://poser.pugx.org/container-interop/container-interop/v/stable.png)](https://packagist.org/packages/container-interop/container-interop)
 [![Total Downloads](https://poser.pugx.org/container-interop/container-interop/downloads.svg)](https://packagist.org/packages/container-interop/container-interop)
 
+## Deprecation warning!
+
+Starting Feb. 13th 2017, container-interop is officially deprecated in favor of [PSR-11](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-11-container.md).
+Container-interop has been the test-bed of PSR-11. From v1.2, container-interop directly extends PSR-11 interfaces.
+Therefore, all containers implementing container-interop are now *de-facto* compatible with PSR-11.
+
+- Projects implementing container-interop interfaces are encouraged to directly implement PSR-11 interfaces instead.
+- Projects consuming container-interop interfaces are very strongly encouraged to directly type-hint on PSR-11 interfaces, in order to be compatible with PSR-11 containers that are not compatible with container-interop.
+
+Regarding the delegate lookup feature, that is present in container-interop and not in PSR-11, the feature is actually a design pattern. It is therefore not deprecated. Documentation regarding this design pattern will be migrated from this repository into a separate website in the future.
+
+## About
+
 *container-interop* tries to identify and standardize features in *container* objects (service locators,
 dependency injection containers, etc.) to achieve interoperability.
 

--- a/composer.json
+++ b/composer.json
@@ -8,5 +8,8 @@
         "psr-4": {
             "Interop\\Container\\": "src/Interop/Container/"
         }
+    },
+    "require": {
+        "psr/container": "^1.0"
     }
 }

--- a/src/Interop/Container/ContainerInterface.php
+++ b/src/Interop/Container/ContainerInterface.php
@@ -5,36 +5,11 @@
 
 namespace Interop\Container;
 
-use Interop\Container\Exception\ContainerException;
-use Interop\Container\Exception\NotFoundException;
+use Psr\Container\ContainerInterface as PsrContainerInterface;
 
 /**
  * Describes the interface of a container that exposes methods to read its entries.
  */
-interface ContainerInterface
+interface ContainerInterface extends PsrContainerInterface
 {
-    /**
-     * Finds an entry of the container by its identifier and returns it.
-     *
-     * @param string $id Identifier of the entry to look for.
-     *
-     * @throws NotFoundException  No entry was found for this identifier.
-     * @throws ContainerException Error while retrieving the entry.
-     *
-     * @return mixed Entry.
-     */
-    public function get($id);
-
-    /**
-     * Returns true if the container can return an entry for the given identifier.
-     * Returns false otherwise.
-     * 
-     * `has($id)` returning true does not mean that `get($id)` will not throw an exception.
-     * It does however mean that `get($id)` will not throw a `NotFoundException`.
-     *
-     * @param string $id Identifier of the entry to look for.
-     *
-     * @return boolean
-     */
-    public function has($id);
 }

--- a/src/Interop/Container/Exception/ContainerException.php
+++ b/src/Interop/Container/Exception/ContainerException.php
@@ -5,9 +5,11 @@
 
 namespace Interop\Container\Exception;
 
+use Psr\Container\ContainerExceptionInterface as PsrContainerException;
+
 /**
  * Base interface representing a generic exception in a container.
  */
-interface ContainerException
+interface ContainerException extends PsrContainerException
 {
 }

--- a/src/Interop/Container/Exception/NotFoundException.php
+++ b/src/Interop/Container/Exception/NotFoundException.php
@@ -5,9 +5,11 @@
 
 namespace Interop\Container\Exception;
 
+use Psr\Container\NotFoundExceptionInterface as PsrNotFoundException;
+
 /**
  * No entry was found in the container.
  */
-interface NotFoundException extends ContainerException
+interface NotFoundException extends ContainerException, PsrNotFoundException
 {
 }


### PR DESCRIPTION
Following discussion at #90, this PR implements PSR-11 and adds a deprecation warning at the forefront of the README.

Closes #90 

Feedback needed. **Not to be merged before Feb 13th!**